### PR TITLE
Shortcode

### DIFF
--- a/FlickrPress.php
+++ b/FlickrPress.php
@@ -162,7 +162,16 @@ class FlickrPress {
 	public static function getQuickSettings() {
 		return get_option(self::getKey('quick_settings'), 0);
 	}
-
+	
+	public static function getFixLinksFilter() { 
+		return get_option(self::getKey('fix_links_filter'), 0);
+	}
+	
+	public static function getFixLinksOnce() { 
+		return get_option(self::getKey('fix_links_once'), 0);
+	}
+	
+	
 	public static function getDefaultLink() {
 		return get_option(self::getKey('default_link'), 'page');
 	}
@@ -235,6 +244,10 @@ class FlickrPress {
 		add_action('admin_action_wpfp_flickr_oauth_callback', array(__CLASS__, 'adminActionWpfpFlickrOauthCallback'));
 		
 		add_shortcode('flickrPhoto',array(__CLASS__, 'WpfpFlickrShortcode'));
+		require_once(self::getDir().'/fix_flickr_links.php');
+		if ( self::getFixLinksFilter() ) {
+			add_filter('the_content','flickrLinkFixer');
+		}
 	}
 
 	public static function adminActionWpfpMediaUpload() {

--- a/FpAdminSettingEvent.php
+++ b/FpAdminSettingEvent.php
@@ -27,6 +27,8 @@ class FpAdminSettingEvent {
 			FlickrPress::getKey('default_file_url_size'),
 			FlickrPress::getKey('extend_link_properties'),
 			FlickrPress::getKey('extend_image_properties'),
+			FlickrPress::getKey('fix_links_once'),
+			FlickrPress::getKey('fix_links_filter'),
 		);
 		return $whitelist_options;
 	}
@@ -384,6 +386,7 @@ function callback_oauth(token) {
 					<p>[img]: Image Tag</p>
 					<p>[title]: Image Title</p>
 					<p>[shortcode]: flickrPhoto shortcode using photo id.</p>
+					<p>[url]: Image URL</p>
 				</th>
 				<td>
 					<textarea name="<?php echo FlickrPress::getKey('insert_template') ?>" cols="70" rows="10"><?php echo FlickrPress::getInsertTemplate() ?></textarea>
@@ -412,6 +415,16 @@ function callback_oauth(token) {
 					<p><?php echo __('When enabled, a dialog will appear when you click for a set of check boxes for multiple insertion.', FlickrPress::TEXT_DOMAIN) ?></p>
 				</td>
 			</tr>
+			<tr valign="top">
+				<th scope="row">
+					<p><?php echo __('Fix Links', FlickrPress::TEXT_DOMAIN) ?></p>
+				</th>
+				<td>
+					<p><?php echo __('Via Filter:', FlickrPress::TEXT_DOMAIN) ?><input type="checkbox" name="<?php echo FlickrPress::getKey('fix_links_filter') ?>" value="1" <?php if (FlickrPress::getFixLinksFilter()=='1') { echo "checked='checked'"; } ?>/></p>
+					<p><?php echo __('Re-sets all image source links based on the preceeding flickr photo page link. Use this if you edit your photos on flickr a lot, and this causes them to disappear often here.', FlickrPress::TEXT_DOMAIN) ?></p>
+				</td>
+			</tr>
+			
 			<tr valign="top">
 				<th scope="row">
 					<p><?php echo __('Search Type', FlickrPress::TEXT_DOMAIN) ?></p>

--- a/fix_flickr_links.php
+++ b/fix_flickr_links.php
@@ -1,0 +1,33 @@
+<?php
+
+function flickrLinkFixer($content)
+{
+	# Find FlickrLink Content
+	
+	$client = FlickrPress::getClient();
+	$url = 'www.flickr.com/photos/';
+	$photo_pattern = '/www\.flickr\.com\/photos\/([\d]+@[\d\w]+)\/([\d]+).+?src="(.+?)"/s';
+	if (strpos( $url , $content) >= 0) {
+		
+		preg_match_all( $photo_pattern , $content, $matches, PREG_SET_ORDER);
+		
+		foreach ($matches as $val) {
+			
+			
+			$user_id = $val[1];
+			$photo_id = $val[2];
+			$old_url = $val[3];
+			
+			$photo = $client->photos_getInfo($photo_id);
+			$new_url = $client->buildPhotoURL($photo['photo']);
+			
+			if ($old_url != $new_url) {
+				$content = str_replace($old_url,$new_url,$content,$count);
+			}
+			
+		}		
+	}
+	return $content;
+}
+
+?>

--- a/media-send-editor.php
+++ b/media-send-editor.php
@@ -105,6 +105,7 @@ function fp_create_image_html($attachments, $orders) {
 		$_html = str_replace('[img]', $_img, $_html);
 		$_html = str_replace('[title]', $alt, $_html);
 		$_html = str_replace('[shortcode]', $_shortcode, $_html);
+		$_html = str_replace('[url]', $link, $_html);
 		$html .= $_html;
 	}
 


### PR DESCRIPTION
I've added a simple short code for wp-flickr-press. This short code solved two problems that I was having:
1. Linking to static images, which I would later edit on Flickr and so would go missing.
2. Quickly including Flickr photos.

I'd like to add a few features to the short code. Future features include:
- Use the Flickr image title as the shortcode-style caption for the image.
- Ensure that the short code respects all of the wp-flickr-press settings
- Make a function to pre-parse the short code so that the short code doesn't need to repeatedly call the flickr API.

I know this implementation is not great without those three things, but I think the short code may be useful for others.
