### PR TITLE
Small change to replace [url] in the insert template with the image link

### DIFF
--- a/media-send-editor.php
+++ b/media-send-editor.php
@@ -101,6 +101,7 @@ function fp_create_image_html($attachments, $orders) {
 		$_html = FlickrPress::getInsertTemplate();
 		$_html = str_replace('[img]', $_img, $_html);
 		$_html = str_replace('[title]', $alt, $_html);
+		$_html = str_replace('[url]', $link, $_html);
 		$html .= $_html;
 	}
 


### PR DESCRIPTION
Small change to replace [url] in the insert template with the image link, useful if the user wants to use the link in the comment. Needed to add this in to let me replace another flickr plugin and keep the same template.
