### PR TITLE
fix for custom post types

### DIFF
--- a/FpThumbnailEvent.php
+++ b/FpThumbnailEvent.php
@@ -67,7 +67,9 @@ class FpThumbnailEvent {
     }
 
     public static function filterWpInsertPostData($data, $postarr) {
-        update_post_meta($postarr['ID'], 'wpfp_use_post_thumbnail', $postarr['wpfp_use_post_thumbnail']);
+    	if ( array_key_exists( 'wpfp_use_post_thumbnail', $postarr ) ) {
+        	update_post_meta($postarr['ID'], 'wpfp_use_post_thumbnail', $postarr['wpfp_use_post_thumbnail']);
+    	}
         return $data;
     }
 


### PR DESCRIPTION
I'm using an ecommerce plugin operating with custom post types for Orders.
They are programmatically created and don't have thumbnails.
So without this patch I'm getting

```
PHP Notice:  Undefined index: wpfp_use_post_thumbnail in /.../wp-content/plugins/wp-flickr-press/FpThumbnailEvent.php on line 70
```
